### PR TITLE
Add whitelist validation for callback data

### DIFF
--- a/tests/callback_data_validation_test.php
+++ b/tests/callback_data_validation_test.php
@@ -1,0 +1,19 @@
+<?php
+require_once __DIR__ . '/../whitelist.php';
+
+function assertEqual($actual, $expected, $message) {
+    if ($actual !== $expected) {
+        fwrite(STDERR, "Assertion failed: $message\n");
+        exit(1);
+    }
+}
+
+assertEqual(validateAssetNetworkParts(explode('|', 'ADD|TGR|TON')), true, 'valid asset and network');
+assertEqual(validateAssetNetworkParts(explode('|', 'ADD|BAD|TON')), false, 'invalid asset');
+assertEqual(validateAssetNetworkParts(explode('|', 'ADD|TGR|BADNET')), false, 'invalid network');
+assertEqual(validateAssetNetworkParts(explode('|', 'ADD|TGR')), false, 'missing parts');
+assertEqual(isValidHistoryType('add'), true, 'valid history type');
+assertEqual(isValidHistoryType('unknown'), false, 'invalid history type');
+
+fwrite(STDOUT, "All callback tests passed.\n");
+?>

--- a/tgbot.php
+++ b/tgbot.php
@@ -23,6 +23,7 @@ include 'func_cheque.php';
 include 'func_staking.php';
 include 'func_exchange.php';
 include 'func_exchange2.php';
+include 'whitelist.php';
 
 #################################
 
@@ -205,36 +206,48 @@ else{
 			delMessage("", $data['callback_query']['message']['message_id']);
 			withdrawFundsListNetworks($asset2wdwFunds);
 		}
-		elseif( preg_match("/ADD\|/", $data['callback_query']['data'])){
+                elseif( preg_match("/ADD\|/", $data['callback_query']['data'])){
       delMessage("", $data['callback_query']['message']['message_id']);
       $p = explode("|", $data['callback_query']['data']);
-			addFundsShowAddress($p[1],$p[2]);
-		}
-		elseif( preg_match("/QR\|/", $data['callback_query']['data'])){
+                        if(validateAssetNetworkParts($p)){
+                            addFundsShowAddress($p[1],$p[2]);
+                        }
+                }
+                elseif( preg_match("/QR\|/", $data['callback_query']['data'])){
       delMessage("", $data['callback_query']['message']['message_id']);
       $p = explode("|", $data['callback_query']['data']);
-			addFundsGetQRcode($p[1],$p[2]);
-		}
-		elseif( preg_match("/CHECK\|/", $data['callback_query']['data'])){
+                        if(validateAssetNetworkParts($p)){
+                            addFundsGetQRcode($p[1],$p[2]);
+                        }
+                }
+                elseif( preg_match("/CHECK\|/", $data['callback_query']['data'])){
       delMessage("", $data['callback_query']['message']['message_id']);
       $p = explode("|", $data['callback_query']['data']);
-			addFundsCheck($p[1],$p[2]);
-		}
-		elseif( preg_match("/WDW\|/", $data['callback_query']['data'])){
+                        if(validateAssetNetworkParts($p)){
+                            addFundsCheck($p[1],$p[2]);
+                        }
+                }
+                elseif( preg_match("/WDW\|/", $data['callback_query']['data'])){
       delMessage("", $data['callback_query']['message']['message_id']);
       $p = explode("|", $data['callback_query']['data']);
-			withdrawFundsWait4Address($p[1],$p[2]);
-		}
-		elseif( preg_match("/HISTORY\|/", $data['callback_query']['data'])){
+                        if(validateAssetNetworkParts($p)){
+                            withdrawFundsWait4Address($p[1],$p[2]);
+                        }
+                }
+                elseif( preg_match("/HISTORY\|/", $data['callback_query']['data'])){
       delMessage("", $data['callback_query']['message']['message_id']);
       $p = explode("|", $data['callback_query']['data']);
-			showHistory($p[1], 0);
-		}
-		elseif( preg_match("/HISTN\|/", $data['callback_query']['data'])){
+                        if(count($p) >= 2 && isValidHistoryType($p[1])){
+                            showHistory($p[1], 0);
+                        }
+                }
+                elseif( preg_match("/HISTN\|/", $data['callback_query']['data'])){
       delMessage("", $data['callback_query']['message']['message_id']);
       $p = explode("|", $data['callback_query']['data']);
-			showHistory($p[1], $p[2]);
-		}
+                        if(count($p) >= 3 && isValidHistoryType($p[1]) && ctype_digit($p[2])){
+                            showHistory($p[1], $p[2]);
+                        }
+                }
 		elseif( $data['callback_query']['data'] == 13 ){
       delMessage("", $data['callback_query']['message']['message_id']);
       transferFunds();

--- a/whitelist.php
+++ b/whitelist.php
@@ -1,0 +1,27 @@
+<?php
+$allowedAssets = ['TON', 'TGR'];
+$allowedNetworks = ['TON', 'BEP20'];
+$allowedHistoryTypes = ['add', 'pauout', 'trans', 'exchange'];
+
+function isValidAsset($asset) {
+    global $allowedAssets;
+    return in_array($asset, $allowedAssets, true);
+}
+
+function isValidNetwork($network) {
+    global $allowedNetworks;
+    return in_array($network, $allowedNetworks, true);
+}
+
+function isValidHistoryType($type) {
+    global $allowedHistoryTypes;
+    return in_array($type, $allowedHistoryTypes, true);
+}
+
+function validateAssetNetworkParts(array $parts) {
+    if (count($parts) < 3) {
+        return false;
+    }
+    return isValidAsset($parts[1]) && isValidNetwork($parts[2]);
+}
+?>


### PR DESCRIPTION
## Summary
- add centralized whitelist for assets, networks, and history types
- validate callback data against whitelist before performing actions
- test incorrect callback data handling

## Testing
- `php tests/callback_data_validation_test.php`
- `php -l tgbot.php`


------
https://chatgpt.com/codex/tasks/task_e_68a9e56ad23c832cabde8efe85f1c21c