### PR TITLE
Validate message deletion parameters and add tests

### DIFF
--- a/func_gen.php
+++ b/func_gen.php
@@ -140,47 +140,84 @@ function save2temp($field, $val){
 }
 
 function delMessage($mid, $cid){
-	global $chat_id;
-		if($mid != ''){
-			$message_id = $mid-1;
-		}
-		elseif($cid != ''){
-			$message_id = $cid;
-		}
-
-		$ch2 = curl_init('https://api.telegram.org/bot' . TOKEN . '/deleteMessage');
-		curl_setopt($ch2, CURLOPT_POST, 1);
-		curl_setopt($ch2, CURLOPT_POSTFIELDS, array('chat_id' => $chat_id, 'message_id' => $message_id));
-		curl_setopt($ch2, CURLOPT_RETURNTRANSFER, true);
-		curl_setopt($ch2, CURLOPT_HEADER, false);
-		$res2 = curl_exec($ch2);
-		curl_close($ch2);
+        global $chat_id;
+        $message_id = null;
+        if(!empty($mid) && is_numeric($mid)){
+                $message_id = $mid-1;
+        }
+        elseif(!empty($cid) && is_numeric($cid)){
+                $message_id = $cid;
+        }
+        if($message_id === null){
+                error_log('delMessage: missing or invalid $mid and $cid');
+                return false;
+        }
+        $ch2 = curl_init('https://api.telegram.org/bot' . TOKEN . '/deleteMessage');
+        curl_setopt($ch2, CURLOPT_POST, 1);
+        curl_setopt($ch2, CURLOPT_POSTFIELDS, array('chat_id' => $chat_id, 'message_id' => $message_id));
+        curl_setopt($ch2, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch2, CURLOPT_HEADER, false);
+        $res2 = curl_exec($ch2);
+        if($res2 === false){
+                error_log('delMessage API error: '.curl_error($ch2));
+                curl_close($ch2);
+                return false;
+        }
+        $resJson = json_decode($res2, true);
+        if(empty($resJson['ok'])){
+                error_log('delMessage API responded with error: '.$res2);
+        }
+        curl_close($ch2);
+        return $resJson['ok'] ?? false;
 }
 
 function delMessage2($mid, $cid){
-	global $chat_id;
-		if($mid != ''){
-			$message_id = $mid-1;
-		}
-		elseif($cid != ''){
-			$message_id = $cid;
-		}
+        global $chat_id;
+        $message_id = null;
+        if(!empty($mid) && is_numeric($mid)){
+                $message_id = $mid-1;
+        }
+        elseif(!empty($cid) && is_numeric($cid)){
+                $message_id = $cid;
+        }
+        if($message_id === null || empty($cid) || !is_numeric($cid)){
+                error_log('delMessage2: missing or invalid $mid and $cid');
+                return false;
+        }
+        $ch2 = curl_init('https://api.telegram.org/bot' . TOKEN . '/deleteMessage');
+        curl_setopt($ch2, CURLOPT_POST, 1);
+        curl_setopt($ch2, CURLOPT_POSTFIELDS, array('chat_id' => $chat_id, 'message_id' => ($cid-1)));
+        curl_setopt($ch2, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch2, CURLOPT_HEADER, false);
+        $res2 = curl_exec($ch2);
+        if($res2 === false){
+                error_log('delMessage2 API error (first call): '.curl_error($ch2));
+                curl_close($ch2);
+                return false;
+        }
+        $resJson = json_decode($res2, true);
+        if(empty($resJson['ok'])){
+                error_log('delMessage2 API responded with error (first call): '.$res2);
+        }
+        curl_close($ch2);
 
-		$ch2 = curl_init('https://api.telegram.org/bot' . TOKEN . '/deleteMessage');
-		curl_setopt($ch2, CURLOPT_POST, 1);
-		curl_setopt($ch2, CURLOPT_POSTFIELDS, array('chat_id' => $chat_id, 'message_id' => ($cid-1)));
-		curl_setopt($ch2, CURLOPT_RETURNTRANSFER, true);
-		curl_setopt($ch2, CURLOPT_HEADER, false);
-		$res2 = curl_exec($ch2);
-		curl_close($ch2);
-
-		$ch2 = curl_init('https://api.telegram.org/bot' . TOKEN . '/deleteMessage');
-		curl_setopt($ch2, CURLOPT_POST, 1);
-		curl_setopt($ch2, CURLOPT_POSTFIELDS, array('chat_id' => $chat_id, 'message_id' => $message_id));
-		curl_setopt($ch2, CURLOPT_RETURNTRANSFER, true);
-		curl_setopt($ch2, CURLOPT_HEADER, false);
-		$res2 = curl_exec($ch2);
-		curl_close($ch2);
+        $ch2 = curl_init('https://api.telegram.org/bot' . TOKEN . '/deleteMessage');
+        curl_setopt($ch2, CURLOPT_POST, 1);
+        curl_setopt($ch2, CURLOPT_POSTFIELDS, array('chat_id' => $chat_id, 'message_id' => $message_id));
+        curl_setopt($ch2, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch2, CURLOPT_HEADER, false);
+        $res2 = curl_exec($ch2);
+        if($res2 === false){
+                error_log('delMessage2 API error (second call): '.curl_error($ch2));
+                curl_close($ch2);
+                return false;
+        }
+        $resJson2 = json_decode($res2, true);
+        if(empty($resJson2['ok'])){
+                error_log('delMessage2 API responded with error (second call): '.$res2);
+        }
+        curl_close($ch2);
+        return $resJson2['ok'] ?? false;
 
 }
 

--- a/tests/DelMessageTest.php
+++ b/tests/DelMessageTest.php
@@ -1,0 +1,28 @@
+<?php
+
+require_once __DIR__ . '/../func_gen.php';
+
+define('TOKEN', 'TEST_TOKEN');
+$chat_id = 1;
+
+$ok = true;
+if(delMessage(null, null) !== false){
+    echo "delMessage without params should return false\n";
+    $ok = false;
+}
+if(delMessage2(5, null) !== false){
+    echo "delMessage2 without cid should return false\n";
+    $ok = false;
+}
+if(delMessage2(null, null) !== false){
+    echo "delMessage2 without params should return false\n";
+    $ok = false;
+}
+
+if($ok){
+    echo "All tests passed\n";
+    exit(0);
+} else {
+    exit(1);
+}
+


### PR DESCRIPTION
## Summary
- Ensure delMessage and delMessage2 only call Telegram API when valid `mid` or `cid` provided
- Add error logging for missing params and API failures
- Include unit tests covering calls without `cid`

## Testing
- `php tests/DelMessageTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68a9e56b1c70832cacb819ac03f435b8