### PR TITLE
Use prepared statements and add SQL injection test

### DIFF
--- a/_0xpay_postback.php
+++ b/_0xpay_postback.php
@@ -8,23 +8,44 @@ $data = json_decode($data, true);
 include 'botdata.php';
 
 include "global.php";
-$link = mysqli_connect($hostName, $userName, $password, $databaseName) or die ("Error connect to database");
+$link = mysqli_connect($hostName, $userName, $password, $databaseName);
+if (!$link) {
+    error_log('DB connection error: ' . mysqli_connect_error());
+    exit();
+}
 mysqli_set_charset($link, "utf8");
 
 include 'func_gen.php';
 
 if($data['status'] == "Done"){
-	$chat_id = $data['meta'];
-	$addedSum = $data['amount'];
+        $chat_id = intval($data['meta']);
+        $addedSum = floatval($data['amount']);
 
-	$str2select = "SELECT * FROM `users` WHERE `chatid`='$chat_id'";
-	$result = mysqli_query($link, $str2select);
-	$row = @mysqli_fetch_object($result);
+        $stmtSel = $link->prepare("SELECT * FROM `users` WHERE `chatid` = ?");
+        if ($stmtSel === false) {
+            error_log('Prepare failed: ' . $link->error);
+            exit();
+        }
+        $stmtSel->bind_param('i', $chat_id);
+        if (!$stmtSel->execute()) {
+            error_log('SQL Error: ' . $stmtSel->error);
+        }
+        $result = $stmtSel->get_result();
+        $row = @mysqli_fetch_object($result);
+        $stmtSel->close();
 
-	$newbalance = $row->tgr_bep20 + $addedSum;
+        $newbalance = $row->tgr_bep20 + $addedSum;
 
-	$str2upd = "UPDATE `users` SET `tgr_bep20`='$newbalance' WHERE `chatid`='$chat_id'";
-	mysqli_query($link, $str2upd);
+        $stmtUpd = $link->prepare("UPDATE `users` SET `tgr_bep20` = ? WHERE `chatid` = ?");
+        if ($stmtUpd === false) {
+            error_log('Prepare failed: ' . $link->error);
+            exit();
+        }
+        $stmtUpd->bind_param('di', $newbalance, $chat_id);
+        if (!$stmtUpd->execute()) {
+            error_log('SQL Error: ' . $stmtUpd->error);
+        }
+        $stmtUpd->close();
 
 	saveTransaction($addedSum, "TGR", "BEP20", "add", 0);
 

--- a/tests/SqlInjectionTest.php
+++ b/tests/SqlInjectionTest.php
@@ -1,0 +1,28 @@
+<?php
+try {
+    $db = new PDO('sqlite::memory:');
+    $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    $db->exec("CREATE TABLE users (id INTEGER PRIMARY KEY, username TEXT)");
+
+    $stmt = $db->prepare("INSERT INTO users(username) VALUES (?)");
+    $malicious = "test'); DROP TABLE users; --";
+    $stmt->execute([$malicious]);
+
+    $row = $db->query("SELECT username FROM users WHERE id = 1")->fetch(PDO::FETCH_ASSOC);
+    if ($row['username'] === $malicious) {
+        echo "Injection prevented\n";
+    } else {
+        echo "Injection occurred\n";
+        exit(1);
+    }
+
+    $tables = $db->query("SELECT name FROM sqlite_master WHERE type='table' AND name='users'")->fetchAll();
+    if (count($tables) !== 1) {
+        echo "Table dropped\n";
+        exit(1);
+    }
+} catch (PDOException $e) {
+    echo "DB Error: " . $e->getMessage() . "\n";
+    exit(1);
+}
+?>

--- a/tgbot.php
+++ b/tgbot.php
@@ -13,8 +13,12 @@ if (empty($data['message']['chat']['id']) AND empty($data['callback_query']['mes
 }
 
 include "global.php";
-$link = mysqli_connect($hostName, $userName, $password, $databaseName) or die ("Error connect to database");
-mysqli_set_charset($link, "utf8");
+$link = mysqli_connect($hostName, $userName, $password, $databaseName);
+if (!$link) {
+    error_log('DB connection error: ' . mysqli_connect_error());
+    exit();
+}
+mysqli_set_charset($link, 'utf8');
 
 include 'botdata.php'; // keys etc.
 include 'func_gen.php';
@@ -26,41 +30,58 @@ include 'func_exchange2.php';
 
 #################################
 
-if (isset($data['message']['chat']['id']))
-{
-	$chat_id = $data['message']['chat']['id'];
-}
-elseif(isset($data['callback_query']['message']['chat']['id']))
-{
-	$chat_id = $data['callback_query']['message']['chat']['id'];
-}
-elseif(isset($data['inline_query']['from']['id']))
-{
-	$chat_id = $data['inline_query']['from']['id'];
+if (isset($data['message']['chat']['id'])) {
+    $chat_id = intval($data['message']['chat']['id']);
+} elseif (isset($data['callback_query']['message']['chat']['id'])) {
+    $chat_id = intval($data['callback_query']['message']['chat']['id']);
+} elseif (isset($data['inline_query']['from']['id'])) {
+    $chat_id = intval($data['inline_query']['from']['id']);
 }
 
 // Register new user in DB
 if(isset($data['callback_query']['message']['chat']['username']) && $data['callback_query']['message']['chat']['username'] != ''){
-	$fname = $data['callback_query']['message']['chat']['first_name'];
-	$lname = $data['callback_query']['message']['chat']['last_name'];
-	$uname = $data['callback_query']['message']['chat']['username'];
+        $fname = $data['callback_query']['message']['chat']['first_name'];
+        $lname = $data['callback_query']['message']['chat']['last_name'];
+        $uname = $data['callback_query']['message']['chat']['username'];
 } else{
-	$fname = $data['message']['from']['first_name'];
-	$lname = $data['message']['from']['last_name'];
-	$uname = $data['message']['from']['username'];
+        $fname = $data['message']['from']['first_name'];
+        $lname = $data['message']['from']['last_name'];
+        $uname = $data['message']['from']['username'];
 }
 $time = time();
 
-	if(empty($uname))$uname = 'undefined';
+        if (empty($uname)) {
+            $uname = 'undefined';
+        }
+        $uname = trim(filter_var($uname, FILTER_SANITIZE_FULL_SPECIAL_CHARS));
 
-	$str2select = "SELECT * FROM `users` WHERE `chatid`='$chat_id'";
-	$result = mysqli_query($link, $str2select);
-	if(mysqli_num_rows($result) == 0){
-		$str2ins = "INSERT INTO `users` (`chatid`,`username`,`tgr_ton`,`tgr_bep20`,`ton_ton`,`tgr_ton_full`,`ton_ton_full`,`ref`,`phone`) VALUES ('$chat_id','$uname', '0', '0', '0', '0', '0', '0', '0')";
-		mysqli_query($link, $str2ins);
-		$result = mysqli_query($link, $str2select);
-	}
-	$row = @mysqli_fetch_object($result);
+        $stmt = $link->prepare("SELECT * FROM `users` WHERE `chatid` = ?");
+        if ($stmt === false) {
+            error_log('Prepare failed: ' . $link->error);
+            exit();
+        }
+        $stmt->bind_param('i', $chat_id);
+        if (!$stmt->execute()) {
+            error_log('SQL Error: ' . $stmt->error);
+        }
+        $result = $stmt->get_result();
+        if (mysqli_num_rows($result) == 0) {
+            $stmtIns = $link->prepare("INSERT INTO `users` (`chatid`,`username`,`tgr_ton`,`tgr_bep20`,`ton_ton`,`tgr_ton_full`,`ton_ton_full`,`ref`,`phone`) VALUES (?, ?, 0, 0, 0, 0, 0, 0, 0)");
+            if ($stmtIns === false) {
+                error_log('Prepare failed: ' . $link->error);
+                exit();
+            }
+            $stmtIns->bind_param('is', $chat_id, $uname);
+            if (!$stmtIns->execute()) {
+                error_log('SQL Error: ' . $stmtIns->error);
+            }
+            $stmtIns->close();
+
+            $stmt->execute();
+            $result = $stmt->get_result();
+        }
+        $row = @mysqli_fetch_object($result);
+        $stmt->close();
 
 // Register new user in DB
 
@@ -511,9 +532,18 @@ else{
         }
   }else{
 
-		$str5select = "SELECT `action` FROM `temp_sess` WHERE `chatid`='$chat_id' ORDER BY `rowid` DESC LIMIT 1";
-		$result5 = mysqli_query($link, $str5select);
-		$row5 = @mysqli_fetch_object($result5);
+                $stmt5 = $link->prepare("SELECT `action` FROM `temp_sess` WHERE `chatid` = ? ORDER BY `rowid` DESC LIMIT 1");
+                if ($stmt5 === false) {
+                    error_log('Prepare failed: ' . $link->error);
+                } else {
+                    $stmt5->bind_param('i', $chat_id);
+                    if (!$stmt5->execute()) {
+                        error_log('SQL Error: ' . $stmt5->error);
+                    }
+                    $result5 = $stmt5->get_result();
+                    $row5 = @mysqli_fetch_object($result5);
+                    $stmt5->close();
+                }
 // Wallet
 		if(preg_match("/withdrawWallet\|/", $row5->action)){
 			withdrawFundsWait4Sum($data, $row5);


### PR DESCRIPTION
## Summary
- replace string-concatenated SQL queries with prepared statements
- validate incoming data and log database errors
- add a simple SQLite test to ensure SQL injection attempts are treated as data

## Testing
- `php -l tgbot.php`
- `php -l _0xpay_postback.php`
- `php -l tests/SqlInjectionTest.php`
- `php tests/SqlInjectionTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68a9e56d7804832ca7419dbc31791053