### PR TITLE
Use environment variables for configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+DB_HOST=localhost
+DB_USER=username
+DB_PASSWORD=password
+DB_NAME=database
+
+BOT_TOKEN=your_telegram_bot_token
+XPAY_MERCHANT_ID=your_xpay_merchant_id
+XPAY_PRIVATE_KEY=your_xpay_private_key
+TON_API_KEY=your_ton_api_key
+MAIN_WALLET=your_main_wallet_address
+GEN_SEED=your_seed_phrase
+TEGROMONEY_SHOP_ID=your_tegromoney_shop_id
+TEGROMONEY_SECRET_KEY=your_tegromoney_secret_key

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.env
+.php_errors.log
+

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ TON Multifunctional Bot is an indispensable assistant for working with TON. From
 
 ### **Setup and Launch**:
 
-1. Fill in the variables in `botdata.php` as per the comments provided in the file.
+1. Copy `.env.example` to `.env`, set database credentials, API keys, and seed phrases as needed, and keep `.env` out of version control.
 2. Add the link to `_0xpay_postback.php` in the postback field of the 0xpay control panel.
 3. Insert the link to `tm_postback.php` in the postback field of the tegro.money control panel.
 4. Set up the cronjobs as follows:

--- a/botdata.php
+++ b/botdata.php
@@ -1,14 +1,15 @@
 <?php
-$xPayMerchantId = '5a6200fe-0798-4b4a-b1c3-2779d42af64a';
-$xPayPrivateKey = '71ba018a2bb3ffb52fcceb9aa3b574bc';
-$tonapikey = 'e52c8854142eba7ba3c015c1b0b046d31e0333a6d25fce4e7872cec7cd9c39e4';
-$mainWallet = 'EQADeT9xqZ4wAam-bCXbTjNhUTN03K33EYQmnL5Q8udk5E2T';
-$genseed = 'tide viable airport master inch weather citizen hood slot wire fatal toy below bring same vocal amused tourist opera seed burger october collect master';
+define('TOKEN', getenv('BOT_TOKEN'));
+$xPayMerchantId = getenv('XPAY_MERCHANT_ID');
+$xPayPrivateKey = getenv('XPAY_PRIVATE_KEY');
+$tonapikey = getenv('TON_API_KEY');
+$mainWallet = getenv('MAIN_WALLET');
+$genseed = getenv('GEN_SEED');
 $tgrbep20fee = 2; // USD
 $tgrtonfee = 0.1; // TON
 $tonfee = 0.1; // TON
-$tegromoney_shopid = "58897C1D797CA1F09A12269C8E40BA69";
-$tegromoney_secretkey = "p3fUjzEM";
+$tegromoney_shopid = getenv('TEGROMONEY_SHOP_ID');
+$tegromoney_secretkey = getenv('TEGROMONEY_SECRET_KEY');
 $chequefee = 0.02;
 $stakingfee[0][0] = 15;
 $stakingfee[0][1] = 18;
@@ -19,4 +20,4 @@ $stakingfee[1][1] = 10;
 $stakingfee[1][2] = 11;
 $stakingfee[1][3] = 12;
 $exchangefee = 0.005;
- ?>
+?>

--- a/global.php
+++ b/global.php
@@ -1,6 +1,6 @@
 <?php
-$hostName = 'localhost';
-$userName = 'tegromoneybot_bot';
-$password = 'TV0Up5ARw036c';
-$databaseName = 'tegromoneybot_bot';
+$hostName = getenv('DB_HOST');
+$userName = getenv('DB_USER');
+$password = getenv('DB_PASSWORD');
+$databaseName = getenv('DB_NAME');
 ?>

--- a/tm_postback.php
+++ b/tm_postback.php
@@ -15,7 +15,7 @@ if($file = fopen("tm_response.txt", "w+")){
     fclose($file);
 } // end frite to file
 
-define('TOKEN', 'УКАЖИТЕ_ЗДЕСЬ-СВОЙ_КЛЮЧ_TELEGRAM_БОТА');
+define('TOKEN', getenv('BOT_TOKEN'));
 
 include "global.php";
 $link = mysqli_connect($hostName, $userName, $password, $databaseName) or die ("Error connect to database");


### PR DESCRIPTION
## Summary
- Load database credentials from environment variables
- Fetch API keys and seed phrase from environment instead of hardcoding
- Provide `.env.example` and ignore `.env`

## Testing
- `php -l global.php`
- `php -l botdata.php`
- `php -l tm_postback.php`


------
https://chatgpt.com/codex/tasks/task_e_68a9e56f9c84832ca0ec22eb8175b520