### PR TITLE
Add basic multilingual support with language switching

### DIFF
--- a/func_cheque.php
+++ b/func_cheque.php
@@ -373,7 +373,7 @@ function chequeGetQRcode($rowid){
     $arInfo["inline_keyboard"][0][0]["text"] = "⏪ Назад в Чеки";
     send($chat_id, 'Ссылка на твой чек:
 <code>'.$a.'</code>', $arInfo);
-
+        $arInfo["inline_keyboard"][0][0]["text"] = t('back_to_main');
     sleep(5);
     unlink($filename);
 }
@@ -474,7 +474,7 @@ function chequeChangeRef($rowid){
     $arInfo["inline_keyboard"][0][1]["text"] = "25%".$ql;
     $ql = ($row->percent == 50) ? "🔸" : "";
     $arInfo["inline_keyboard"][0][2]["callback_data"] = "CRF|50|$rowid";
-    $arInfo["inline_keyboard"][0][2]["text"] = "50%".$ql;
+    $arInfo["inline_keyboard"][0][2]["text"] = "50%".$ql;        $arInfo["inline_keyboard"][0][0]["text"] = t('back_to_main');
     $ql = ($row->percent == 75) ? "🔸" : "";
     $arInfo["inline_keyboard"][0][3]["callback_data"] = "CRF|75|$rowid";
     $arInfo["inline_keyboard"][0][3]["text"] = "75%".$ql;

--- a/func_gen.php
+++ b/func_gen.php
@@ -63,39 +63,36 @@ function send2($method, $request)
 }
 
 function mainMenu(){
-	global $chat_id, $link, $langcode, $text;
+        global $chat_id;
 
-    $arInfo["keyboard"][0][0]["text"] = "↩️ В главное меню";
+    $arInfo["keyboard"][0][0]["text"] = t('menu_back');
     $arInfo["resize_keyboard"] = TRUE;
-    send($chat_id, ' Рады приветствовать тебя в криптовалютном кошельке Libermall Bot!', $arInfo);
+    send($chat_id, t('welcome'), $arInfo);
 
     unset($arInfo);
 
     $arInfo["inline_keyboard"][0][0]["callback_data"] = 1;
-  $arInfo["inline_keyboard"][0][0]["text"] = "💎 Кошелек";
-  $arInfo["inline_keyboard"][0][1]["callback_data"] = 2;
-  $arInfo["inline_keyboard"][0][1]["text"] = "🏷 Чеки";
-  #$arInfo["inline_keyboard"][1][0]["callback_data"] = 3;
-  #$arInfo["inline_keyboard"][1][0]["text"] = "🗳 Обмен";
-  $arInfo["inline_keyboard"][1][0]["callback_data"] = 4;
-  $arInfo["inline_keyboard"][1][0]["text"] = "💹 Биржа";
-  $arInfo["inline_keyboard"][2][0]["callback_data"] = 5;
-  $arInfo["inline_keyboard"][2][0]["text"] = "💸 Маркет";
-  $arInfo["inline_keyboard"][2][1]["callback_data"] = 6;
-  $arInfo["inline_keyboard"][2][1]["text"] = "🪪 Счета";
-  $arInfo["inline_keyboard"][3][0]["callback_data"] = 7;
-  $arInfo["inline_keyboard"][3][0]["text"] = "💰 Сделки";
-  $arInfo["inline_keyboard"][3][1]["callback_data"] = 8;
-  $arInfo["inline_keyboard"][3][1]["text"] = "📈 Стейкинг";
-  $arInfo["inline_keyboard"][4][0]["callback_data"] = 9;
-  $arInfo["inline_keyboard"][4][0]["text"] = "🖼 NFT";
-  $arInfo["inline_keyboard"][4][1]["callback_data"] = 10;
-  $arInfo["inline_keyboard"][4][1]["text"] = "⚙️ Настройки";
+    $arInfo["inline_keyboard"][0][0]["text"] = t('menu_wallet');
+    $arInfo["inline_keyboard"][0][1]["callback_data"] = 2;
+    $arInfo["inline_keyboard"][0][1]["text"] = t('menu_checks');
+    $arInfo["inline_keyboard"][1][0]["callback_data"] = 4;
+    $arInfo["inline_keyboard"][1][0]["text"] = t('menu_exchange');
+    $arInfo["inline_keyboard"][2][0]["callback_data"] = 5;
+    $arInfo["inline_keyboard"][2][0]["text"] = "💸 Маркет";
+    $arInfo["inline_keyboard"][2][1]["callback_data"] = 6;
+    $arInfo["inline_keyboard"][2][1]["text"] = "🪪 Счета";
+    $arInfo["inline_keyboard"][3][0]["callback_data"] = 7;
+    $arInfo["inline_keyboard"][3][0]["text"] = "💰 Сделки";
+    $arInfo["inline_keyboard"][3][1]["callback_data"] = 8;
+    $arInfo["inline_keyboard"][3][1]["text"] = "📈 Стейкинг";
+    $arInfo["inline_keyboard"][4][0]["callback_data"] = 9;
+    $arInfo["inline_keyboard"][4][0]["text"] = "🖼 NFT";
+    $arInfo["inline_keyboard"][4][1]["callback_data"] = 10;
+    $arInfo["inline_keyboard"][4][1]["text"] = t('menu_settings');
 
-	send($chat_id, "Мультивалютный криптокошелек libermall.com. Покупайте, продавайте, храните и платите криптовалютой когда хотите.
-
-Подписывайтесь на <a href='https://t.me/LibermallRUS'>наш канал</a> и вступайте в <a href='https://t.me/libermallton'>наш чат</a>.", $arInfo);
+        send($chat_id, t('main_menu_text'), $arInfo);
 }
+
 
 function getRowUsers(){
 		global $link, $chat_id;

--- a/func_lang.php
+++ b/func_lang.php
@@ -1,0 +1,41 @@
+<?php
+$translations = [];
+$user_lang = 'en';
+
+function loadTranslations(){
+    global $translations;
+    $base = __DIR__ . '/lang';
+    foreach(glob($base.'/*.php') as $file){
+        $lang = basename($file, '.php');
+        $translations[$lang] = include $file;
+    }
+}
+
+function getUserLang($chat_id){
+    global $link;
+    $res = mysqli_query($link, "SELECT `lang` FROM `users` WHERE `chatid`='".mysqli_real_escape_string($link,$chat_id)."'");
+    if($row = mysqli_fetch_assoc($res)){
+        return $row['lang'] ?: 'en';
+    }
+    return 'en';
+}
+
+function setUserLang($chat_id, $lang){
+    global $link;
+    $lang = mysqli_real_escape_string($link, $lang);
+    mysqli_query($link, "UPDATE `users` SET `lang`='$lang' WHERE `chatid`='".mysqli_real_escape_string($link,$chat_id)."'");
+}
+
+function t($key){
+    global $translations, $user_lang;
+    return $translations[$user_lang][$key] ?? $key;
+}
+
+function languageMenu(){
+    global $chat_id;
+    $arInfo["inline_keyboard"][0][0]["text"] = 'English';
+    $arInfo["inline_keyboard"][0][0]["callback_data"] = 'setlang_en';
+    $arInfo["inline_keyboard"][0][1]["text"] = 'Русский';
+    $arInfo["inline_keyboard"][0][1]["callback_data"] = 'setlang_ru';
+    send($chat_id, t('choose_language'), $arInfo);
+}

--- a/func_staking.php
+++ b/func_staking.php
@@ -14,7 +14,7 @@ function stakingMenu(){
         $i = 2;
     }
     $arInfo["inline_keyboard"][$i][0]["callback_data"] = 15;
-    $arInfo["inline_keyboard"][$i][0]["text"] = "⏪ Назад на главную";
+    $arInfo["inline_keyboard"][$i][0]["text"] = t('back_to_main');
     send($chat_id, "Получайте вознаграждение, размещая в стейкинге цифровые активы.", $arInfo);
 }
 function stakingChooseAsset(){

--- a/lang/en.php
+++ b/lang/en.php
@@ -1,0 +1,14 @@
+<?php
+return [
+    'menu_back' => '↩️ Main menu',
+    'welcome' => 'Welcome to Libermall crypto wallet!',
+    'menu_wallet' => '💎 Wallet',
+    'menu_checks' => '🏷 Checks',
+    'menu_exchange' => '💹 Exchange',
+    'menu_settings' => '⚙️ Settings',
+    'menu_language' => '🌐 Language',
+    'choose_language' => 'Choose language',
+    'language_saved' => 'Language updated',
+    'back_to_main' => '⏪ Back to main',
+    'main_menu_text' => "Multicurrency crypto wallet libermall.com. Buy, sell, store and pay with cryptocurrency whenever you want.\n\nSubscribe to <a href='https://t.me/LibermallRUS'>our channel</a> and join <a href='https://t.me/libermallton'>our chat</a>.",
+];

--- a/lang/ru.php
+++ b/lang/ru.php
@@ -1,0 +1,14 @@
+<?php
+return [
+    'menu_back' => '↩️ В главное меню',
+    'welcome' => 'Рады приветствовать тебя в криптовалютном кошельке Libermall Bot!',
+    'menu_wallet' => '💎 Кошелек',
+    'menu_checks' => '🏷 Чеки',
+    'menu_exchange' => '💹 Биржа',
+    'menu_settings' => '⚙️ Настройки',
+    'menu_language' => '🌐 Язык',
+    'choose_language' => 'Выберите язык',
+    'language_saved' => 'Язык обновлен',
+    'back_to_main' => '⏪ Назад на главную',
+    'main_menu_text' => "Мультивалютный криптокошелек libermall.com. Покупайте, продавайте, храните и платите криптовалютой когда хотите.\n\nПодписывайтесь на <a href='https://t.me/LibermallRUS'>наш канал</a> и вступайте в <a href='https://t.me/libermallton'>наш чат</a>.",
+];

--- a/tgbot.php
+++ b/tgbot.php
@@ -23,6 +23,7 @@ include 'func_cheque.php';
 include 'func_staking.php';
 include 'func_exchange.php';
 include 'func_exchange2.php';
+include 'func_lang.php';
 
 #################################
 
@@ -56,11 +57,13 @@ $time = time();
 	$str2select = "SELECT * FROM `users` WHERE `chatid`='$chat_id'";
 	$result = mysqli_query($link, $str2select);
 	if(mysqli_num_rows($result) == 0){
-		$str2ins = "INSERT INTO `users` (`chatid`,`username`,`tgr_ton`,`tgr_bep20`,`ton_ton`,`tgr_ton_full`,`ton_ton_full`,`ref`,`phone`) VALUES ('$chat_id','$uname', '0', '0', '0', '0', '0', '0', '0')";
-		mysqli_query($link, $str2ins);
-		$result = mysqli_query($link, $str2select);
-	}
-	$row = @mysqli_fetch_object($result);
+                $str2ins = "INSERT INTO `users` (`chatid`,`username`,`tgr_ton`,`tgr_bep20`,`ton_ton`,`tgr_ton_full`,`ton_ton_full`,`ref`,`phone`,`lang`) VALUES ('$chat_id','$uname', '0', '0', '0', '0', '0', '0', '0','en')";
+                mysqli_query($link, $str2ins);
+                $result = mysqli_query($link, $str2select);
+        }
+        $row = @mysqli_fetch_object($result);
+        loadTranslations();
+        $user_lang = getUserLang($chat_id);
 
 // Register new user in DB
 
@@ -104,7 +107,7 @@ $r = saveReferral($data);
 if($r == true) mainMenu();
 
 }
-elseif( preg_match("/В главное меню/", $data['message']['text'] )){
+elseif( $data['message']['text'] == t('menu_back') ){
     delMessage("", $data['callback_query']['message']['message_id']);
     mainMenu();
 }
@@ -138,6 +141,12 @@ elseif( preg_match("/\/exchange/", $data['message']['text'] )){
     exchange2Start();
 
 }
+elseif( preg_match("/\/language/", $data['message']['text'] )){
+
+    delMessage2("", $data['callback_query']['message']['message_id']);
+    languageMenu();
+
+}
 elseif( preg_match("/\/help/i", $data['message']['text'] )){
 
 }
@@ -151,8 +160,17 @@ else{
 
   if(isset($data['callback_query']['data']) && $data['callback_query']['data'] != ''){
 
+                if(preg_match('/^setlang_/', $data['callback_query']['data'])){
+                        $lang = substr($data['callback_query']['data'],8);
+                        setUserLang($chat_id, $lang);
+                        $user_lang = $lang;
+                        delMessage("", $data['callback_query']['message']['message_id']);
+                        send($chat_id, t('language_saved'), NULL);
+                        mainMenu();
+                }
+
 // Wallet
-		if( $data['callback_query']['data'] == 1 || $data['callback_query']['data'] == 25 || $data['callback_query']['data'] == 34 ){
+                elseif( $data['callback_query']['data'] == 1 || $data['callback_query']['data'] == 25 || $data['callback_query']['data'] == 34 ){
       delMessage2("", $data['callback_query']['message']['message_id']);
       walletMenu();
     }


### PR DESCRIPTION
## Summary
- move interface strings into new lang/en.php and lang/ru.php
- add translation helper `t()` and language selection menu
- implement `/language` command and store chosen language

## Testing
- `php -l func_lang.php`
- `php -l lang/en.php`
- `php -l lang/ru.php`
- `php -l tgbot.php`
- `php -l func_gen.php`
- `php -l func_staking.php`
- `php -l func_cheque.php`


------
https://chatgpt.com/codex/tasks/task_e_68a9e573a5d4832c876585ce5e7bc3be